### PR TITLE
Always add whitespace_validation to _Choices

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -810,20 +810,14 @@ def create_command(tool, model, **kwargs):
                 ## not useful for choices, input fields ...
 
                 if not is_boolean_parameter(param) and type(param.restrictions) is _Choices :
-                    # if default value is present in select list, no need to check for whitespaces
-                    if is_selection_parameter(param) and param.default in param.restrictions.choices:
-                        command += "#if " + actual_parameter + ":\n"
-                        command += '  %s %s\n' % (param_cli_name, actual_parameter)
-                        command += "#end if\n" 
-                    else:
-                        command += "#if " + actual_parameter + ":\n"
-                        command += '  %s\n' % param_cli_name
-                        command += "  #if \" \" in str(" + actual_parameter + "):\n"
-                        command += "    \"" + actual_parameter + "\"\n"
-                        command += "  #else\n"
-                        command += "    " + actual_parameter + "\n"
-                        command += "  #end if\n"
-                        command += "#end if\n" 
+                    command += "#if " + actual_parameter + ":\n"
+                    command += '  %s\n' % param_cli_name
+                    command += "  #if \" \" in str(" + actual_parameter + "):\n"
+                    command += "    \"" + actual_parameter + "\"\n"
+                    command += "  #else\n"
+                    command += "    " + actual_parameter + "\n"
+                    command += "  #end if\n"
+                    command += "#end if\n" 
                 elif is_boolean_parameter(param):
                     command += "#if " + actual_parameter + ":\n"
                     command += '  %s\n' % param_cli_name


### PR DESCRIPTION
_Choices (e.g. select lists) can have whitespaces in their options even if they are default values / predefined, therefore I would check for that always since some tools won't run otherwise.

It might be a simpler solution to always escape string parameters, but since I assume there is a reason why it hasn't be done and can't check further now, I'll go for the smallest change to fix this error.

Fixes https://github.com/galaxyproteomics/tools-galaxyp/pull/147