### PR TITLE
[fix] suggestion to fix #20

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -1282,14 +1282,15 @@ def create_output_node(parent, param, model, supported_file_formats):
             # set the first data output node to the first file format
 
             # check if there are formats that have not been registered yet...
-            output = ""
+            output = list()
             for format_name in param.restrictions.formats:
                 if not format_name in supported_file_formats.keys():
-                    output += " " + str(format_name)
+                    output.append(str(format_name))
 
             # warn only if there's about to complain
             if output:
-                warning("Parameter " + param.name + " has the following unsupported format(s):" + output, 1)
+                warning("Parameter " + param.name + " has the following unsupported format(s):" + ','.join(output), 1)
+                data_format = ','.join(output)
 
             formats = get_supported_file_types(param.restrictions.formats, supported_file_formats)
             try:


### PR DESCRIPTION
By default, 'data' is used as format attribute in the ```<outputs>``` tag.
However, if format is contained in CTD, then this is carried over and a support warning is given; if a supported file formats is given and contains the format given in the CTD, it gets transformed as given in the supported file formats file.